### PR TITLE
Add iOS (aarch64) build and switch non-Windows output to wee8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     container: ${{ matrix.target.container }}
     steps:
       - name: Check out the code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Install dependencies on Ubuntu
         if: startsWith(matrix.target.id, 'linux-amd64')
@@ -159,7 +159,7 @@ jobs:
       #     ls -lh dist/v8.tar.xz
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.target.id }}
           path: dist
@@ -175,7 +175,7 @@ jobs:
 
     steps:
       - name: Download the Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,13 +134,17 @@ jobs:
         shell: bash
         run: |
           mkdir -p dist
-          tar --directory v8/out/dist --create --xz --verbose ${{ matrix.target.tar_extra_args }} --file dist/v8.tar.xz include lib
+          tar --directory v8/out/dist --create --xz --verbose ${{ matrix.target.tar_extra_args }} --file dist/v8.tar.xz include obj
           ls -lh dist/v8.tar.xz
 
       - name: Zip (Windows)
         if: matrix.target.id == 'windows-amd64'
         shell: bash
         run: |
+          # Windows builds the v8_monolith ninja target rather than
+          # wee8 because wee8 has dllimport/dllexport issues on
+          # Windows. It packages as lib/v8.lib, so the tar layout
+          # here stays on include/lib.
           mkdir -p dist
           tar --directory v8/out/dist --create --xz --verbose ${{ matrix.target.tar_extra_args }} --file dist/v8.tar.xz include lib
           ls -lh dist/v8.tar.xz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             os: 'macos-15'
             native: true
           - id: 'ios'
-            os: 'darwin-aarch64'
+            os: 'macos-15'
             native: false
           - id: 'android'
             os: 'ubuntu-22.04'

--- a/build.sh
+++ b/build.sh
@@ -143,11 +143,10 @@ gn gen out/release --args="is_debug=false \
 fi
 
 # Showtime!
-if [ "$OS" == "ios" ]; then
-  ninja -C out/release v8_monolith
-else
-  ninja -C out/release wee8
-fi
+# wee8 bundles the wasm-c-api shim (wasm_engine_new, wasm_module_new, ...)
+# that downstream consumers link against. v8_monolith is larger but
+# omits those C-ABI symbols.
+ninja -C out/release wee8
 
 ls -laR out/release/obj
 
@@ -170,11 +169,7 @@ find "$DIST_DIR/include" -type f ! -name "*.h" -delete
 cp third_party/wasm-api/wasm.h "$DIST_DIR/include/wasm-c-api/wasm.h"
 
 # Copy the library (renamed to libv8.a)
-if [ "$OS" == "ios" ]; then
-  cp out/release/obj/libv8_monolith.a "$DIST_DIR/lib/libv8.a"
-else
-  cp out/release/obj/libwee8.a "$DIST_DIR/lib/libv8.a"
-fi
+cp out/release/obj/libwee8.a "$DIST_DIR/lib/libv8.a"
 
 echo "=== Distribution layout ==="
 find "$DIST_DIR" -type f | sort

--- a/build.sh
+++ b/build.sh
@@ -150,15 +150,15 @@ ninja -C out/release wee8
 
 ls -laR out/release/obj
 
-# Package the output into a proper directory structure:
-#   include/         - V8 public headers
-#   include/wasm-c-api/wasm.h - Wasm C API header (patched)
-#   lib/libv8.a      - The built library
+# Package into dist layout:
+#   include/                    - V8 public headers
+#   include/wasm-c-api/wasm.h   - patched wasm-c-api header
+#   obj/libwee8.a               - built library
 DIST_DIR="out/dist"
 rm -rf "$DIST_DIR"
 mkdir -p "$DIST_DIR/include"
 mkdir -p "$DIST_DIR/include/wasm-c-api"
-mkdir -p "$DIST_DIR/lib"
+mkdir -p "$DIST_DIR/obj"
 
 # Copy V8 public headers (preserving subdirectory structure)
 cp -R include/* "$DIST_DIR/include/"
@@ -168,8 +168,7 @@ find "$DIST_DIR/include" -type f ! -name "*.h" -delete
 # Copy the patched wasm C API header
 cp third_party/wasm-api/wasm.h "$DIST_DIR/include/wasm-c-api/wasm.h"
 
-# Copy the library (renamed to libv8.a)
-cp out/release/obj/libwee8.a "$DIST_DIR/lib/libv8.a"
+cp out/release/obj/libwee8.a "$DIST_DIR/obj/libwee8.a"
 
 echo "=== Distribution layout ==="
 find "$DIST_DIR" -type f | sort

--- a/build.sh
+++ b/build.sh
@@ -78,6 +78,10 @@ done
 
 if [ "$OS" == "ios" ]
 then
+# V8's iOS profile turns lite_mode on (and wasm/turbofan off) by
+# default whenever ios_deployment_target != "17.4". Pin all three
+# related flags explicitly so the output is deterministic regardless
+# of that target.
 gn gen out/release --args="is_debug=false \
   v8_symbol_level=0 \
   symbol_level = 0 \
@@ -100,6 +104,9 @@ gn gen out/release --args="is_debug=false \
   v8_enable_handle_zapping = false \
   v8_enable_pointer_compression = true \
   v8_enable_short_builtin_calls = true \
+  v8_enable_lite_mode = false \
+  v8_enable_webassembly = true \
+  v8_enable_turbofan = true \
   v8_monolithic = true \
   ios_enable_code_signing = false \
   target_cpu=\"$ARCH\" \


### PR DESCRIPTION
Adds an iOS aarch64 build, drops the iOS-specific `v8_monolith` path in favour of `wee8` uniformly, and aligns the non-Windows tar layout with the wee8 artifact path.

### What this does

- Fixes the iOS matrix entry's runner label (`darwin-aarch64` is not a real label).
- Pins `v8_enable_lite_mode=false` / `v8_enable_webassembly=true` / `v8_enable_turbofan=true` on iOS so the build is deterministic regardless of `ios_deployment_target`. Without this, V8's `gni/v8.gni` silently forces lite mode (no wasm, no turbofan) and torque errors out.
- Builds `wee8` on every platform except Windows. `v8_monolith` omits the wasm-c-api shim (`wasm_engine_new`, `wasm_module_new`, …) that downstream consumers link against.
- Packages the non-Windows tar at `obj/libwee8.a` instead of renaming to `lib/libv8.a`. Downstream tooling that unpacks a wee8 archive already expects this path.
- Bumps `actions/checkout`, `actions/upload-artifact`, `actions/download-artifact` to their latest Node-24 majors so the deprecation warnings go away before GitHub forces the runtime in June.

### Not touched

- **Windows.** `build.ps1` still targets `v8_monolith` (wee8 has dllimport/dllexport issues on Windows) and still packages at `lib/v8.lib`. The Windows Zip step keeps tarring `include lib`.
- **Published release layout consumers.** Existing non-Windows consumers that expect `lib/libv8.a` will need to read from `obj/libwee8.a` after this lands.

### Runtime note

The iOS build contains JIT codegen paths. Apple does not grant the JIT entitlement to non-browser apps, so an embedder targeting the App Store needs to initialize V8 with `--jitless` at runtime. That's an embedder-side concern; the build itself does not enforce it.