### PR TITLE
fix(Memory): properly preserve shared attribute of a Memory

### DIFF
--- a/patches/0001-Add-ability-to-define-sharedness-of-memory.patch
+++ b/patches/0001-Add-ability-to-define-sharedness-of-memory.patch
@@ -23,7 +23,7 @@ index 9d59c97e225..4ad54f3f6cb 100644
        return MemoryType::make(limits);
      }
      case i::wasm::kExternalGlobal: {
-@@ -2286,7 +2287,8 @@ WASM_EXPORT auto Memory::make(Store* store_abs, const MemoryType* type)
+@@ -2284,7 +2285,8 @@ WASM_EXPORT auto Memory::make(Store* store_abs, const MemoryType* type)
      if (maximum > i::wasm::kSpecMaxMemory32Pages) return nullptr;
    }
    // TODO(wasm+): Support shared memory and memory64.
@@ -33,7 +33,26 @@ index 9d59c97e225..4ad54f3f6cb 100644
    i::wasm::AddressType address_type = i::wasm::AddressType::kI32;
    i::DirectHandle<i::WasmMemoryObject> memory_obj;
    if (!i::WasmMemoryObject::New(isolate, minimum, maximum, shared, address_type)
-diff --git a/third_party/wasm-api/wasm.h b/third_party/wasm-api/wasm.h
+@@ -2301,7 +2303,8 @@ WASM_EXPORT auto Memory::type() const -> own<MemoryType> {
+                                        i::wasm::kWasmPageSize);
+   uint32_t max =
+       memory->has_maximum_pages() ? memory->maximum_pages() : 0xFFFFFFFFu;
+-  return MemoryType::make(Limits(min, max));
++  return MemoryType::make(
++      Limits(min, max, memory->array_buffer()->is_shared()));
+ }
+ 
+ WASM_EXPORT auto Memory::data() const -> byte_t* {
+@@ -2720,7 +2723,7 @@ extern "C++" inline auto hide_limits(const wasm::Limits& limits)
+ }
+ 
+ extern "C++" inline auto reveal_limits(wasm_limits_t limits) -> wasm::Limits {
+-  return wasm::Limits(limits.min, limits.max);
++  return wasm::Limits(limits.min, limits.max, limits.shared);
+ }
+ 
+ extern "C++" inline auto hide_valkind(wasm::ValKind kind) -> wasm_valkind_t {
+diff --git i/third_party/wasm-api/wasm.h w/third_party/wasm-api/wasm.h
 index 99a35dabc77..50a05297712 100644
 --- a/third_party/wasm-api/wasm.h
 +++ b/third_party/wasm-api/wasm.h

--- a/patches/0002-Add-support-for-tags-eh.patch
+++ b/patches/0002-Add-support-for-tags-eh.patch
@@ -200,16 +200,7 @@ index 8650fb3549b..15fceadff2e 100644
  // Table Instances
  
  template <>
-@@ -2305,7 +2425,7 @@ WASM_EXPORT auto Memory::type() const -> own<MemoryType> {
-                                        i::wasm::kWasmPageSize);
-   uint32_t max =
-       memory->has_maximum_pages() ? memory->maximum_pages() : 0xFFFFFFFFu;
--  return MemoryType::make(Limits(min, max));
-+  return MemoryType::make(Limits(min, max, false));
- }
- 
- WASM_EXPORT auto Memory::data() const -> byte_t* {
-@@ -2471,6 +2591,10 @@ WASM_EXPORT auto Instance::exports() const -> ownvec<Extern> {
+@@ -2470,6 +2592,10 @@ WASM_EXPORT auto Instance::exports() const -> ownvec<Extern> {
          exports[i] = implement<Memory>::type::make(
              store, i::Cast<i::WasmMemoryObject>(obj));
        } break;
@@ -220,16 +211,7 @@ index 8650fb3549b..15fceadff2e 100644
      }
    }
  
-@@ -2724,7 +2848,7 @@ extern "C++" inline auto hide_limits(const wasm::Limits& limits)
- }
- 
- extern "C++" inline auto reveal_limits(wasm_limits_t limits) -> wasm::Limits {
--  return wasm::Limits(limits.min, limits.max);
-+  return wasm::Limits(limits.min, limits.max, limits.shared);
- }
- 
- extern "C++" inline auto hide_valkind(wasm::ValKind kind) -> wasm_valkind_t {
-@@ -2804,6 +2928,17 @@ wasm_mutability_t wasm_globaltype_mutability(const wasm_globaltype_t* gt) {
+@@ -2803,6 +2929,17 @@ wasm_mutability_t wasm_globaltype_mutability(const wasm_globaltype_t* gt) {
    return hide_mutability(gt->mutability());
  }
  


### PR DESCRIPTION
The following Wasmer test-case was failing before my change:
```
 for memory_type in [
        MemoryType::new(Pages(1), Some(Pages(2)), false),
        MemoryType::new(Pages(1), Some(Pages(2)), true),
    ] {
        let memory = Memory::new(&mut store, memory_type).map_err(|e| format!("{e:?}"))?;
        assert_eq!(memory.ty(&store), memory_type);
    }
```

Noticed while working on the V8 in Wasmer: #6121.