### PR TITLE
CI: disable iOS for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
           - id: 'darwin-aarch64'
             os: 'macos-15'
             native: true
-          - id: 'ios'
-            os: 'darwin-aarch64'
-            native: false
+          # - id: 'ios'
+          #   os: 'darwin-aarch64'
+          #   native: false
           - id: 'android'
             os: 'ubuntu-22.04'
             native: false


### PR DESCRIPTION
For a proper release to be built, I need green CI.

Related to #8 that's going to be properly implemented in a separate PR.