### PR TITLE
feat(Memory): implement shareable memory usable by multiple Isolates

### DIFF
--- a/patches/0007-shared-memory.patch
+++ b/patches/0007-shared-memory.patch
@@ -52,7 +52,7 @@ index ddb7fa93369..fadf87287d1 100644
 +  auto shared = std::make_unique<SharedMemoryData>();
 +  shared->backing_store = buffer->GetBackingStore();
 +  shared->maximum_pages =
-+      memory->has_maximum_pages() ? memory->maximum_pages() : v8::internal::wasm::kNoMaximum;
++      memory->has_maximum_pages() ? memory->maximum_pages() : i::WasmMemoryObject::kNoMaximum;
 +  shared->address_type = memory->address_type();
 +  return make_own(seal<Shared<Memory>>(shared.release()));
 +}

--- a/patches/0007-shared-memory.patch
+++ b/patches/0007-shared-memory.patch
@@ -1,0 +1,190 @@
+diff --git i/src/wasm/c-api.cc w/src/wasm/c-api.cc
+index ddb7fa93369..fadf87287d1 100644
+--- i/src/wasm/c-api.cc
++++ w/src/wasm/c-api.cc
+@@ -2405,12 +2405,79 @@ struct implement<Memory> {
+   using type = RefImpl<Memory, i::WasmMemoryObject>;
+ };
+ 
++struct SharedMemoryData {
++  std::shared_ptr<i::BackingStore> backing_store;
++  int maximum_pages;
++  i::wasm::AddressType address_type;
++};
++
++template <>
++struct implement<Shared<Memory>> {
++  using type = SharedMemoryData;
++};
++
++namespace {
++
++void UpdateSharedWasmMemoryIfNeeded(i::Isolate* isolate,
++                                    i::Tagged<i::WasmMemoryObject> memory) {
++  i::Tagged<i::JSArrayBuffer> buffer = memory->array_buffer();
++  if (!buffer->is_shared()) return;
++  std::shared_ptr<i::BackingStore> backing_store = buffer->GetBackingStore();
++  if (backing_store && backing_store->is_wasm_memory()) {
++    backing_store->UpdateSharedWasmMemoryObjects(isolate);
++  }
++}
++
++}  // namespace
++
+ WASM_EXPORT void Memory::destroy() { delete impl(this); }
+ 
+ WASM_EXPORT auto Memory::copy() const -> own<Memory> {
+   return impl(this)->copy();
+ }
+ 
++WASM_EXPORT void Shared<Memory>::destroy() { delete impl(this); }
++
++WASM_EXPORT auto Memory::share() const -> own<Shared<Memory>> {
++  i::Isolate* isolate = impl(this)->isolate();
++  v8::Isolate::Scope isolate_scope(reinterpret_cast<v8::Isolate*>(isolate));
++  PtrComprCageAccessScope ptr_compr_cage_access_scope(isolate);
++  i::HandleScope handle_scope(isolate);
++
++  i::DirectHandle<i::WasmMemoryObject> memory = impl(this)->v8_object();
++  i::Tagged<i::JSArrayBuffer> buffer = memory->array_buffer();
++  if (!buffer->is_shared()) return own<Shared<Memory>>();
++
++  auto shared = std::make_unique<SharedMemoryData>();
++  shared->backing_store = buffer->GetBackingStore();
++  shared->maximum_pages =
++      memory->has_maximum_pages() ? memory->maximum_pages() : v8::internal::wasm::kNoMaximum;
++  shared->address_type = memory->address_type();
++  return make_own(seal<Shared<Memory>>(shared.release()));
++}
++
++WASM_EXPORT auto Memory::obtain(Store* store_abs, const Shared<Memory>* shared)
++    -> own<Memory> {
++  StoreImpl* store = impl(store_abs);
++  i::Isolate* isolate = store->i_isolate();
++  v8::Isolate::Scope isolate_scope(store->isolate());
++  i::HandleScope scope(isolate);
++  CheckAndHandleInterrupts(isolate);
++
++  const SharedMemoryData* shared_data = impl(shared);
++  if (!shared_data || !shared_data->backing_store ||
++      !shared_data->backing_store->is_shared()) {
++    return own<Memory>();
++  }
++
++  i::DirectHandle<i::JSArrayBuffer> buffer =
++      isolate->factory()->NewJSSharedArrayBuffer(shared_data->backing_store);
++  i::DirectHandle<i::WasmMemoryObject> memory =
++      i::WasmMemoryObject::New(isolate, buffer, shared_data->maximum_pages,
++                               shared_data->address_type);
++  return implement<Memory>::type::make(store, memory);
++}
++
+ WASM_EXPORT auto Memory::make(Store* store_abs, const MemoryType* type)
+     -> own<Memory> {
+   StoreImpl* store = impl(store_abs);
+@@ -2442,8 +2509,11 @@ WASM_EXPORT auto Memory::make(Store* store_abs, const MemoryType* type)
+ }
+ 
+ WASM_EXPORT auto Memory::type() const -> own<MemoryType> {
+-  PtrComprCageAccessScope ptr_compr_cage_access_scope(impl(this)->isolate());
++  i::Isolate* isolate = impl(this)->isolate();
++  v8::Isolate::Scope isolate_scope(reinterpret_cast<v8::Isolate*>(isolate));
++  PtrComprCageAccessScope ptr_compr_cage_access_scope(isolate);
+   i::DirectHandle<i::WasmMemoryObject> memory = impl(this)->v8_object();
++  UpdateSharedWasmMemoryIfNeeded(isolate, *memory);
+   uint32_t min = static_cast<uint32_t>(memory->array_buffer()->byte_length() /
+                                        i::wasm::kWasmPageSize);
+   uint32_t max =
+@@ -2456,6 +2526,7 @@ WASM_EXPORT auto Memory::data() const -> byte_t* {
+   i::Isolate* isolate = impl(this)->isolate();
+   v8::Isolate::Scope isolate_scope(reinterpret_cast<v8::Isolate*>(isolate));
+   PtrComprCageAccessScope ptr_compr_cage_access_scope(isolate);
++  UpdateSharedWasmMemoryIfNeeded(isolate, *impl(this)->v8_object());
+   return reinterpret_cast<byte_t*>(
+       impl(this)->v8_object()->array_buffer()->backing_store());
+ }
+@@ -2464,6 +2535,7 @@ WASM_EXPORT auto Memory::data_size() const -> size_t {
+   i::Isolate* isolate = impl(this)->isolate();
+   v8::Isolate::Scope isolate_scope(reinterpret_cast<v8::Isolate*>(isolate));
+   PtrComprCageAccessScope ptr_compr_cage_access_scope(isolate);
++  UpdateSharedWasmMemoryIfNeeded(isolate, *impl(this)->v8_object());
+   return impl(this)->v8_object()->array_buffer()->byte_length();
+ }
+ 
+@@ -2471,6 +2543,7 @@ WASM_EXPORT auto Memory::size() const -> pages_t {
+   i::Isolate* isolate = impl(this)->isolate();
+   v8::Isolate::Scope isolate_scope(reinterpret_cast<v8::Isolate*>(isolate));
+   PtrComprCageAccessScope ptr_compr_cage_access_scope(isolate);
++  UpdateSharedWasmMemoryIfNeeded(isolate, *impl(this)->v8_object());
+   return static_cast<pages_t>(
+       impl(this)->v8_object()->array_buffer()->byte_length() /
+       i::wasm::kWasmPageSize);
+@@ -3592,7 +3665,7 @@ bool wasm_table_grow(wasm_table_t* table, wasm_table_size_t delta,
+ 
+ // Memory Instances
+ 
+-WASM_DEFINE_REF(memory, wasm::Memory)
++WASM_DEFINE_SHARABLE_REF(memory, wasm::Memory)
+ 
+ wasm_memory_t* wasm_memory_new(wasm_store_t* store,
+                                const wasm_memorytype_t* type) {
+@@ -3617,6 +3690,15 @@ bool wasm_memory_grow(wasm_memory_t* memory, wasm_memory_pages_t delta) {
+   return memory->grow(delta);
+ }
+ 
++wasm_shared_memory_t* wasm_memory_share(const wasm_memory_t* memory) {
++  return release_shared_memory(reveal_memory(memory)->share());
++}
++
++wasm_memory_t* wasm_memory_obtain(wasm_store_t* store,
++                                  const wasm_shared_memory_t* shared) {
++  return release_memory(wasm::Memory::obtain(store, reveal_shared_memory(shared)));
++}
++
+ // Externals
+ 
+ WASM_DEFINE_REF(extern, wasm::Extern)
+diff --git i/third_party/wasm-api/wasm.h w/third_party/wasm-api/wasm.h
+index 843f67c9fe2..8dad7d11c4e 100644
+--- i/third_party/wasm-api/wasm.h
++++ w/third_party/wasm-api/wasm.h
+@@ -498,7 +498,7 @@ WASM_API_EXTERN bool wasm_table_grow(wasm_table_t*, wasm_table_size_t delta, was
+ 
+ // Memory Instances
+ 
+-WASM_DECLARE_REF(memory)
++WASM_DECLARE_SHARABLE_REF(memory)
+ 
+ typedef uint32_t wasm_memory_pages_t;
+ 
+diff --git i/third_party/wasm-api/wasm.hh w/third_party/wasm-api/wasm.hh
+index e5024a14a54..41533bc9dfd 100644
+--- i/third_party/wasm-api/wasm.hh
++++ w/third_party/wasm-api/wasm.hh
+@@ -859,6 +859,9 @@ public:
+   static auto make(Store*, const MemoryType*) -> own<Memory>;
+   auto copy() const -> own<Memory>;
+ 
++  auto share() const -> own<Shared<Memory>>;
++  static auto obtain(Store*, const Shared<Memory>*) -> own<Memory>;
++
+   using pages_t = uint32_t;
+ 
+   static const size_t page_size = 0x10000;
+@@ -870,6 +873,16 @@ public:
+   auto grow(pages_t delta) -> bool;
+ };
+ 
++template<>
++class WASM_API_EXTERN Shared<Memory> {
++  friend class destroyer;
++  void destroy();
++
++protected:
++  Shared() = default;
++  ~Shared() = default;
++};
++
+ 
+ // Module Instances
+ 


### PR DESCRIPTION
So far, we relied on the `wasm_memory_copy` functionality, but again, it's something that can't work among multiple Isolates. Rather, we must create a memory instance that shares the `BackingStore`. By having that, all the WASIX tests are green.