### PR TITLE
fix(Windows): build WASM C API and packages as v8.lib

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -56,14 +56,15 @@ v8_enable_gdbjit = false
 v8_use_external_startup_data = false
 v8_enable_pointer_compression = true
 v8_enable_short_builtin_calls = true
+v8_monolithic = true
 treat_warnings_as_errors = false
 target_cpu = "x64"
 v8_target_cpu = "x64"
 '@ | Set-Content -Path "out\release\args.gn" -Encoding utf8
 gn gen out/release
 
-# Showtime!
-ninja -C out/release wee8
+# Showtime! (wee8 has dllimport/dllexport issues on Windows, use v8_monolith instead)
+ninja -C out/release v8_monolith
 
 Get-ChildItem -Recurse out/release/obj
 
@@ -86,8 +87,8 @@ Get-ChildItem -Path "include" -Directory | ForEach-Object {
 # Copy the patched wasm C API header
 Copy-Item -Path "third_party\wasm-api\wasm.h" -Destination "$DIST_DIR\include\wasm-c-api\wasm.h"
 
-# Copy the library (renamed from wee8.lib to v8.lib)
-Copy-Item -Path "out\release\obj\wee8.lib" -Destination "$DIST_DIR\lib\v8.lib"
+# Copy the library (renamed from v8_monolith.lib to v8.lib)
+Copy-Item -Path "out\release\obj\v8_monolith.lib" -Destination "$DIST_DIR\lib\v8.lib"
 
 Write-Host "=== Distribution layout ==="
 Get-ChildItem -Recurse -File $DIST_DIR | ForEach-Object { Write-Host $_.FullName }

--- a/build.ps1
+++ b/build.ps1
@@ -56,15 +56,14 @@ v8_enable_gdbjit = false
 v8_use_external_startup_data = false
 v8_enable_pointer_compression = true
 v8_enable_short_builtin_calls = true
-v8_monolithic = true
 treat_warnings_as_errors = false
 target_cpu = "x64"
 v8_target_cpu = "x64"
 '@ | Set-Content -Path "out\release\args.gn" -Encoding utf8
 gn gen out/release
 
-# Showtime! (wee8 has dllimport/dllexport issues on Windows, use v8_monolith instead)
-ninja -C out/release v8_monolith
+# Showtime!
+ninja -C out/release wee8
 
 Get-ChildItem -Recurse out/release/obj
 
@@ -87,8 +86,8 @@ Get-ChildItem -Path "include" -Directory | ForEach-Object {
 # Copy the patched wasm C API header
 Copy-Item -Path "third_party\wasm-api\wasm.h" -Destination "$DIST_DIR\include\wasm-c-api\wasm.h"
 
-# Copy the library (renamed from v8_monolith.lib to v8.lib)
-Copy-Item -Path "out\release\obj\v8_monolith.lib" -Destination "$DIST_DIR\lib\v8.lib"
+# Copy the library (renamed from wee8.lib to v8.lib)
+Copy-Item -Path "out\release\obj\wee8.lib" -Destination "$DIST_DIR\lib\v8.lib"
 
 Write-Host "=== Distribution layout ==="
 Get-ChildItem -Recurse -File $DIST_DIR | ForEach-Object { Write-Host $_.FullName }

--- a/patches/0008-Define-LIBWASM_STATIC-for-wee8.patch
+++ b/patches/0008-Define-LIBWASM_STATIC-for-wee8.patch
@@ -1,0 +1,15 @@
+diff --git a/BUILD.gn b/BUILD.gn
+index 44f5e49afce..3529d25bf3d 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -7241,6 +7241,10 @@ if (v8_enable_webassembly) {
+ 
+     configs = [ ":internal_config" ]
+ 
++    if (is_win) {
++      defines = [ "LIBWASM_STATIC" ]
++    }
++
+     sources = [
+       ### gcmole(all) ###
+       "src/wasm/c-api.cc",


### PR DESCRIPTION
Try putting back the WASM C API symbols into the built `v8` static library.